### PR TITLE
Added NSNumberFormatter for easier number formatting

### DIFF
--- a/Example/ValueStepper/Base.lproj/Main.storyboard
+++ b/Example/ValueStepper/Base.lproj/Main.storyboard
@@ -104,14 +104,9 @@
                                     </mask>
                                 </variation>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d0U-vq-Wf0" customClass="ValueStepper" customModule="ValueStepper">
-                                <rect key="frame" x="229.5" y="45" width="141" height="29"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="d0U-vq-Wf0" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="25" id="0Ul-jW-u1h"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="4FP-zi-NyV"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="top" secondItem="Dzk-BA-h5o" secondAttribute="bottom" constant="20" id="8WJ-2l-47a"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="CB6-v4-StF"/>
@@ -119,7 +114,6 @@
                             <constraint firstItem="03c-0U-hbd" firstAttribute="leading" secondItem="Dzk-BA-h5o" secondAttribute="trailing" constant="15" id="OJw-Du-1wu"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="S1E-bD-G86"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="top" secondItem="hh2-tW-5BE" secondAttribute="bottom" constant="20" id="Yhy-xm-KQQ"/>
-                            <constraint firstItem="d0U-vq-Wf0" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="cIg-Bg-cii"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="leading" secondItem="hh2-tW-5BE" secondAttribute="trailing" constant="15" id="fay-RZ-JUW"/>
                             <constraint firstItem="hh2-tW-5BE" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="h9o-GD-cUs"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="p2z-2w-sBM"/>

--- a/Example/ValueStepper/Base.lproj/Main.storyboard
+++ b/Example/ValueStepper/Base.lproj/Main.storyboard
@@ -104,9 +104,14 @@
                                     </mask>
                                 </variation>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d0U-vq-Wf0" customClass="ValueStepper" customModule="ValueStepper">
+                                <rect key="frame" x="229.5" y="45" width="141" height="29"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="d0U-vq-Wf0" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="25" id="0Ul-jW-u1h"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="4FP-zi-NyV"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="top" secondItem="Dzk-BA-h5o" secondAttribute="bottom" constant="20" id="8WJ-2l-47a"/>
                             <constraint firstItem="03c-0U-hbd" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="CB6-v4-StF"/>
@@ -114,6 +119,7 @@
                             <constraint firstItem="03c-0U-hbd" firstAttribute="leading" secondItem="Dzk-BA-h5o" secondAttribute="trailing" constant="15" id="OJw-Du-1wu"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="S1E-bD-G86"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="top" secondItem="hh2-tW-5BE" secondAttribute="bottom" constant="20" id="Yhy-xm-KQQ"/>
+                            <constraint firstItem="d0U-vq-Wf0" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="cIg-Bg-cii"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="leading" secondItem="hh2-tW-5BE" secondAttribute="trailing" constant="15" id="fay-RZ-JUW"/>
                             <constraint firstItem="hh2-tW-5BE" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="h9o-GD-cUs"/>
                             <constraint firstItem="Dzk-BA-h5o" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="p2z-2w-sBM"/>

--- a/Example/ValueStepper/ViewController.swift
+++ b/Example/ValueStepper/ViewController.swift
@@ -10,16 +10,6 @@ import UIKit
 import ValueStepper
 
 class ViewController: UIViewController {
-    
-    let integerValueStepper: ValueStepper = {
-        let stepper = ValueStepper()
-        stepper.tintColor = .whiteColor()
-        stepper.minimumValue = 0
-        stepper.maximumValue = 1000
-        stepper.stepValue = 100
-        stepper.valueType = .Integer
-        return stepper
-    }()
 
     @IBOutlet weak var stepper1: ValueStepper!
     @IBOutlet weak var stepper2: ValueStepper!
@@ -28,7 +18,12 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        stepper3.valueType = .Integer
+        // Set up currency number formatter
+        let moneyFormatter = NSNumberFormatter()
+        moneyFormatter.numberStyle = .CurrencyStyle
+        moneyFormatter.maximumFractionDigits = 0
+        stepper3.numberFormatter = moneyFormatter
+        
         stepper3.addTarget(self, action: "valueChanged3:", forControlEvents: .ValueChanged)
     }
     

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -64,6 +64,14 @@ private enum Button: Int {
         }
     }
     
+    /// Describes the format of the value.
+    private var numberFormatter: NSNumberFormatter = {
+        let formatter = NSNumberFormatter()
+        formatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+    
     // Default width of the stepper. Taken from the official UIStepper object.
     public let defaultWidth = 141.0
     

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -287,11 +287,11 @@ private enum Button: Int {
     // MARK: Actions
     
     private func setState() {
-        if value.round1 >= maximumValue {
+        if value.rounded(numberFormatter.maximumFractionDigits) >= maximumValue {
             increaseButton.enabled = false
             increaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()
-        } else if value.round1 <= minimumValue {
+        } else if value.rounded(numberFormatter.maximumFractionDigits) <= minimumValue {
             decreaseButton.enabled = false
             decreaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()
@@ -305,14 +305,7 @@ private enum Button: Int {
     
     // Display the value with the
     private func setFormattedValue(value: Double) {
-        switch valueType {
-        case .Integer:
-            valueLabel.text = String(Int(value))
-        case .OneDecimal:
-            valueLabel.text = String(value.round1)
-        case .TwoDecimal:
-            valueLabel.text = String(value.round2)
-        }
+        valueLabel.text = numberFormatter.stringFromNumber(value)
     }
     
     // Update all the subviews tintColor properties.
@@ -328,6 +321,8 @@ private enum Button: Int {
 // MARK: Double - Extension
 
 extension Double {
-    var round1: Double { return Double(round(100 * self) / 100) }
-    var round2: Double { return Double(round(1000 * self) / 1000) }
+    func rounded(digits: Int) -> Double {
+        let decimalValue = pow(10.0, Double(digits))
+        return round(self * decimalValue) / decimalValue
+    }
 }

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -132,6 +132,7 @@ private enum Button: Int {
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        translatesAutoresizingMaskIntoConstraints = false
         setUp()
     }
     
@@ -148,6 +149,22 @@ private enum Button: Int {
         decreaseButton.addTarget(self, action: "selected:", forControlEvents: .TouchDown)
         increaseButton.addTarget(self, action: "selected:", forControlEvents: .TouchDown)
     }
+    
+    // MARK: Storyboard preview setup
+    
+    override public func prepareForInterfaceBuilder() {
+        setUp()
+    }
+    
+    public override func intrinsicContentSize() -> CGSize {
+        return CGSize(width: defaultWidth, height: defaultHeight)
+    }
+    
+    override public class func requiresConstraintBasedLayout() -> Bool {
+        return true
+    }
+    
+    // MARK: Lifecycle
     
     public override func layoutSubviews() {
         // Size constants
@@ -318,7 +335,7 @@ private enum Button: Int {
     
 }
 
-// MARK: Double - Extension
+// MARK: Double rounding - Extension
 
 extension Double {
     func rounded(digits: Int) -> Double {

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -289,11 +289,11 @@ private enum Button: Int {
     // MARK: Actions
     
     private func setState() {
-        if value.rounded(numberFormatter.maximumFractionDigits) >= maximumValue {
+        if value >= maximumValue {
             increaseButton.enabled = false
             increaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()
-        } else if value.rounded(numberFormatter.maximumFractionDigits) <= minimumValue {
+        } else if value <= minimumValue {
             decreaseButton.enabled = false
             decreaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()
@@ -318,13 +318,4 @@ private enum Button: Int {
         rightSeparator.strokeColor = tintColor.CGColor
     }
     
-}
-
-// MARK: Double rounding - Extension
-
-extension Double {
-    func rounded(digits: Int) -> Double {
-        let decimalValue = pow(10.0, Double(digits))
-        return round(self * decimalValue) / decimalValue
-    }
 }

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -118,7 +118,6 @@ private enum Button: Int {
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        translatesAutoresizingMaskIntoConstraints = false
         setUp()
     }
     

--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -8,17 +8,6 @@
 
 import UIKit
 
-/// The type of value of number.
-///
-/// - Integer:    The number without decimal part.
-/// - OneDecimal: The number rounded to the first decimal digit.
-/// - TwoDecimal: The number rounded to the second decimal digit.
-public enum NumberType {
-    case Integer
-    case OneDecimal
-    case TwoDecimal
-}
-
 /// Button tags
 ///
 /// - Decrease: Decrease button has tag 0.
@@ -57,20 +46,17 @@ private enum Button: Int {
     /// When set to true, keeping a button pressed will continuously increase/decrease the value every 0.1s.
     @IBInspectable public var autorepeat: Bool = true
     
-    /// The type of value that the value represents.
-    public var valueType: NumberType = .OneDecimal {
+    /// Describes the format of the value.
+    public var numberFormatter: NSNumberFormatter = {
+        let formatter = NSNumberFormatter()
+        formatter.numberStyle = .DecimalStyle
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }() {
         didSet {
             setFormattedValue(value)
         }
     }
-    
-    /// Describes the format of the value.
-    private var numberFormatter: NSNumberFormatter = {
-        let formatter = NSNumberFormatter()
-        formatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
-        formatter.maximumFractionDigits = 2
-        return formatter
-    }()
     
     // Default width of the stepper. Taken from the official UIStepper object.
     public let defaultWidth = 141.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ let valueStepper: ValueStepper = {
     stepper.minimumValue = 0
     stepper.maximumValue = 1000
     stepper.stepValue = 100
-    stepper.valueType = .Integer
     return stepper
 }()
 
@@ -60,8 +59,8 @@ These are the available properties with the relative documentation.
 /// When set to true, keeping a button pressed will continuously increase/decrease the value every 0.1s.
 @IBInspectable public var autorepeat: Bool = true
     
-/// The type of value that the value represents.
-public var valueType: NumberType = .OneDecimal
+/// Describes the format of the value.
+public var numberFormatter: NSNumberFormatter
     
 // Default width of the stepper. Taken from the official UIStepper object.
 public let defaultWidth = 141.0


### PR DESCRIPTION
Fixed #1 

It's now possible to customize or provide a `NSNumberFormatter` object in this way:

``` swift
let moneyFormatter = NSNumberFormatter()
moneyFormatter.numberStyle = .CurrencyStyle
moneyFormatter.maximumFractionDigits = 0
stepper.numberFormatter = moneyFormatter
```

Or simply modify the default `NSNumberFormatter`:

``` swift
stepper3.numberFormatter.maximumFractionDigits = 1
```
