### PR TITLE
Fixed bug with inability to select maximum and minimum values

### DIFF
--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -289,11 +289,11 @@ import UIKit
     
     // Set correct state of the buttons (in case we reached the minimum or maximum value).
     private func setState() {
-        if (value + stepValue) >= maximumValue {
+        if (value + stepValue) > maximumValue {
             increaseButton.enabled = false
             increaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()
-        } else if (value - stepValue) <= minimumValue {
+        } else if (value - stepValue) < minimumValue {
             decreaseButton.enabled = false
             decreaseLayer.strokeColor = UIColor.grayColor().CGColor
             continuousTimer?.invalidate()


### PR DESCRIPTION
In current version increase and decrease buttons becomes disabled when **_`value ± stepValue ≥≤ max/min`**_, but condition **_`equal`**_ means what we can perform one more step.
