### PR TITLE
allow subclassing, use single quotes in readme

### DIFF
--- a/Pod/Classes/ValueStepper.swift
+++ b/Pod/Classes/ValueStepper.swift
@@ -17,7 +17,7 @@ private enum Button: Int {
     case increase
 }
 
-@IBDesignable public class ValueStepper: UIControl {
+@IBDesignable public open class ValueStepper: UIControl {
     
     // MARK - Public variables
     

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ValueStepper is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your `Podfile`:
 
 ```ruby
-pod "ValueStepper"
+pod 'ValueStepper'
 ```
 
 You can also use [Carthage](https://github.com/Carthage/Carthage) if you prefer. Add this line to your `Cartfile`.


### PR DESCRIPTION
1) Added the `open` keyword so that apps can subclass `ValueStepper`
2) Single quotes seem to be the default style to be used in the Podfile...